### PR TITLE
Add www to sitemaps.org link

### DIFF
--- a/sitemap.xsl
+++ b/sitemap.xsl
@@ -51,7 +51,7 @@
                     </h2>
                     <p>
                         This is an XML sitemap, meant for consumption by search engines.<br/>
-                        You can find more information about XML sitemaps on <a href="https://sitemaps.org" class="link blue">sitemaps.org</a>.
+                        You can find more information about XML sitemaps on <a href="https://www.sitemaps.org" class="link blue">sitemaps.org</a>.
                     </p>
                 </header>
 


### PR DESCRIPTION
As far as I can tell, the url [sitemaps.org](https://sitemaps.org/) doesn't seem to respond, only [www.sitemaps.org](https://www.sitemaps.org).